### PR TITLE
Fix bugs, security issues, and improve cross-platform compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,7 +220,7 @@ logs/
 **/bin/
 **/obj/
 my-safe-directory/
-obsolette/
+obsolete/
 settings
 .DS_Store
 *.log

--- a/cockroachdb/docker-compose.yml
+++ b/cockroachdb/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   us-east:
-    image: cockroachdb/cockroach:${CRDB_VERSION}
-    platform: linux/arm64
+    image: cockroachdb/cockroach:${CRDB_VERSION:?Set CRDB_VERSION e.g. export CRDB_VERSION=v24.3.1}
+    # platform: linux/arm64  # Uncomment if running on Apple Silicon; omit for amd64
     container_name: us-east
     hostname: us-east
     volumes:
@@ -32,8 +32,8 @@ services:
       - dcp-net
 
   us-central:
-    image: cockroachdb/cockroach:${CRDB_VERSION}
-    platform: linux/arm64
+    image: cockroachdb/cockroach:${CRDB_VERSION:?Set CRDB_VERSION e.g. export CRDB_VERSION=v24.3.1}
+    # platform: linux/arm64  # Uncomment if running on Apple Silicon; omit for amd64
     container_name: us-central
     hostname: us-central
     volumes:
@@ -61,8 +61,8 @@ services:
       - dcp-net
 
   us-west:
-    image: cockroachdb/cockroach:${CRDB_VERSION}
-    platform: linux/arm64
+    image: cockroachdb/cockroach:${CRDB_VERSION:?Set CRDB_VERSION e.g. export CRDB_VERSION=v24.3.1}
+    # platform: linux/arm64  # Uncomment if running on Apple Silicon; omit for amd64
     container_name: us-west
     hostname: us-west
     volumes:
@@ -90,8 +90,8 @@ services:
       - dcp-net
 
   init:
-    image: cockroachdb/cockroach:${CRDB_VERSION}
-    platform: linux/arm64
+    image: cockroachdb/cockroach:${CRDB_VERSION:?Set CRDB_VERSION e.g. export CRDB_VERSION=v24.3.1}
+    # platform: linux/arm64  # Uncomment if running on Apple Silicon; omit for amd64
     container_name: init
     depends_on:
       - us-east
@@ -115,4 +115,4 @@ volumes:
 
 networks:
   dcp-net:
-    external: true
+    external: true  # Run: docker network create dcp-net  before docker-compose up


### PR DESCRIPTION
## Summary

Fixes for the issues identified in #1. Addresses bugs, security concerns, and cross-platform compatibility.

### Bug fixes
- **`render_haproxy_cfg()` missing comma** — Python's implicit string concatenation glued the `stats socket` line to the empty string, producing a malformed HAProxy config with no newline between the `global` block and `defaults`
- **`init_cluster()` crashes on already-initialized clusters** — `ssh()` defaulted to `check=True`, so `cockroach init` returning nonzero (already initialized) raised `RuntimeError` before the "already initialized" string check. Now uses `check=False` and raises on truly unexpected output
- **`wait_for_expected_nodes()` dead code** — the `"is_live" not in header` guard always hit `continue` before the `try/except ValueError` could fire. Consolidated into a single `try/except` with `continue` on `ValueError`
- **`docker-compose.yml` hardcoded `platform: linux/arm64`** — commented out with a note to uncomment on Apple Silicon; lets Docker infer the correct platform on amd64
- **`docker-compose.yml` silent `CRDB_VERSION` failure** — changed `${CRDB_VERSION}` to `${CRDB_VERSION:?...}` so an unset env var produces a clear error instead of pulling an empty image tag
- **`docker-compose.yml` undocumented `dcp-net` prereq** — added inline comment noting `docker network create dcp-net` must be run first

### Security improvements
- **Password redaction in logs** — added `_redact_cmd()` helper so `run()` no longer prints passwords in `ALTER USER ... WITH PASSWORD '...'` statements to stdout
- **Restrictive temp file permissions** — `scp_text()` now sets `umask 0o077` so temp files (which may contain cert keys or configs) are not world-readable between write and scp
- **Root certs limited to seed node** — `install_crdb_certs()` now only deploys `client.root.*` to the seed node (first in the list); other nodes only need the CA and their own node certs
- **Password removed from psql URI** — `validate_region_password()` now uses `PGPASSWORD` env var instead of embedding the password in the connection string (visible in `ps` and `run()` logs)
- **Warning comments** — added on `SSH_OPTS` (demo-only host-key skip) and the default `--password` value

### Code quality
- **`from __future__ import annotations`** — enables `str | None` and `tuple[Path, Path]` type hints on Python 3.8+ (previously required 3.10+)
- **Error messages don't leak commands** — `RuntimeError` now shows exit code instead of the full command string (which could contain secrets)
- **`.gitignore` typo** — `obsolette/` → `obsolete/`

### Items NOT addressed (require owner input)
- Missing directories (`pgbouncer/`, `terraform/`, `kafka/`, `workloads/`) — these appear to be in a separate repo or not yet committed
- README content fixes (truncated sentence, `docker exec -it` in loops, `ipconfig getifaddr en0` macOS-only) — left for a follow-up since the README is extensive
- `.gitignore` bloat — left as-is since trimming it is a style preference

See #1 for the full review.

## Test plan
- [ ] `python3 -c "import py_compile; py_compile.compile('controller.py', doraise=True)"` — compiles cleanly
- [ ] Run `controller.py` with `--start-nodes new` and verify only the seed node gets `client.root.*` certs
- [ ] Run `controller.py` with `--auth-mode password` and verify passwords are redacted in stdout
- [ ] `docker-compose up` on an amd64 machine — should no longer fail on `platform: linux/arm64`
- [ ] `docker-compose up` without `CRDB_VERSION` set — should produce a clear error message
- [ ] Verify HAProxy config output has proper newlines (no concatenated lines in `global` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)